### PR TITLE
Update FileIO.py

### DIFF
--- a/Core/FileIO.py
+++ b/Core/FileIO.py
@@ -7,7 +7,7 @@ from .Debug import LogInfo
 
 def readString(filepath:str):
     # 读取字符串文件
-    with open(filepath, "r+") as file:
+    with open(filepath, "r+",encoding="utf-8") as file:
         return file.read()
     
 def writeString(filepath:str,data:str):


### PR DESCRIPTION
fix #4
读文件的时候规定了下用 `utf-8` 编码，就不会炸了