### PR TITLE
再改改最后的指令

### DIFF
--- a/Docs/Guide.md
+++ b/Docs/Guide.md
@@ -81,7 +81,11 @@ cards:
 ## 构建主页
 现在我们在解压后的目录下运行
 ```bash
+# 于 Windows 操作系统
 python main.py -o <Project.yml的路径> -w <输出文件路径>
+
+# 于 MacOS / Linux 操作系统
+python3 main.py -o <Project.yml的路径> -w <输出文件路径>
 ```
 
 > [!TIP]


### PR DESCRIPTION
参考 https://github.com/Light-Beacon/HomepageBuilder/pull/3#discussion_r1545588469
分开了 Windows 和 MacOS / Linux 下的指令

于 Windows 上仍然使用 python 而不是 python3 是因为在 Win11 下就算安装了 Python 也仍然指向了 MsStore